### PR TITLE
Fix VS2005-style lib.exe calling

### DIFF
--- a/supalink.cpp
+++ b/supalink.cpp
@@ -76,6 +76,14 @@ static void Fallback(const char* msg = 0)
         "LINK.EXE ",
         "link ",
         "LINK ",
+		"lib.exe\" ",
+        "LIB.EXE\" ",
+        "lib\" ",
+        "LIB\" ",
+        "lib.exe ",
+        "LIB.EXE ",
+        "lib ",
+        "LIB ",
     };
     string cmd;
     string replaceWith = "link.exe.supalink_orig.exe";


### PR DESCRIPTION
VS2005's lib.exe calls link.exe with its own unmodified command line (so
link.exe believes it's symlinked to lib.exe). Threat "lib.exe" in the
command line as a synonym for "link.exe" to allow Supalink to work in
this case.
